### PR TITLE
Globalize ``package`` and ``require`` so it persists, and create ``shell.append_path`` setting.

### DIFF
--- a/switchcraft/data/computercraft/lua/bios.lua
+++ b/switchcraft/data/computercraft/lua/bios.lua
@@ -721,6 +721,11 @@ settings.define("bios.strict_globals", {
     description = "Prevents assigning variables into a program's environment. Make sure you use the local keyword or assign to _G explicitly.",
     type = "boolean",
 })
+settings.define("shell.append_path", {
+    default = "",
+    description = [[A string to append to path, double check before restarting.]],
+    type = "string",
+})
 settings.define("shell.autocomplete_hidden", {
     default = false,
     description = [[Autocomplete hidden files and folders (those starting with ".").]],

--- a/switchcraft/data/computercraft/lua/bios.lua
+++ b/switchcraft/data/computercraft/lua/bios.lua
@@ -483,6 +483,9 @@ function dofile(_sFile)
     end
 end
 
+local make_package = dofile("rom/modules/main/cc/require.lua").make
+require, package = make_package(_G, "/")
+
 -- Install the rest of the OS api
 function os.run(_tEnv, _sPath, ...)
     expect(1, _tEnv, "table")

--- a/switchcraft/data/computercraft/lua/rom/modules/main/cc/require.lua
+++ b/switchcraft/data/computercraft/lua/rom/modules/main/cc/require.lua
@@ -1,0 +1,147 @@
+--[[- This provides a pure Lua implementation of the builtin @{require} function
+and @{package} library.
+
+Generally you do not need to use this module - it is injected into the every
+program's environment. However, it may be useful when building a custom shell or
+when running programs yourself.
+
+@module cc.require
+@since 1.88.0
+@see using_require For an introduction on how to use @{require}.
+@usage Construct the package and require function, and insert them into a
+custom environment.
+
+    local r = require "cc.require"
+    local env = setmetatable({}, { __index = _ENV })
+    env.require, env.package = r.make(env, "/")
+
+    -- Now we have our own require function, separate to the original.
+    local r2 = env.require "cc.require"
+    print(r, r2)
+]]
+
+local expect = require and require("cc.expect") or dofile("rom/modules/main/cc/expect.lua")
+local expect = expect.expect
+
+local function preload(package)
+    return function(name)
+        if package.preload[name] then
+            return package.preload[name]
+        else
+            return nil, "no field package.preload['" .. name .. "']"
+        end
+    end
+end
+
+local function from_file(package, env)
+    return function(name)
+        local sPath, sError = package.searchpath(name, package.path)
+        if not sPath then
+            return nil, sError
+        end
+        local fnFile, sError = loadfile(sPath, nil, env)
+        if fnFile then
+            return fnFile, sPath
+        else
+            return nil, sError
+        end
+    end
+end
+
+local function make_searchpath(dir)
+    return function(name, path, sep, rep)
+        expect(1, name, "string")
+        expect(2, path, "string")
+        sep = expect(3, sep, "string", "nil") or "."
+        rep = expect(4, rep, "string", "nil") or "/"
+
+        local fname = string.gsub(name, sep:gsub("%.", "%%%."), rep)
+        local sError = ""
+        for pattern in string.gmatch(path, "[^;]+") do
+            local sPath = string.gsub(pattern, "%?", fname)
+            if sPath:sub(1, 1) ~= "/" then
+                sPath = fs.combine(dir, sPath)
+            end
+            if fs.exists(sPath) and not fs.isDir(sPath) then
+                return sPath
+            else
+                if #sError > 0 then
+                    sError = sError .. "\n  "
+                end
+                sError = sError .. "no file '" .. sPath .. "'"
+            end
+        end
+        return nil, sError
+    end
+end
+
+local function make_require(package)
+    local sentinel = {}
+    return function(name)
+        expect(1, name, "string")
+
+        if package.loaded[name] == sentinel then
+            error("loop or previous error loading module '" .. name .. "'", 0)
+        end
+
+        if package.loaded[name] then
+            return package.loaded[name]
+        end
+
+        local sError = "module '" .. name .. "' not found:"
+        for _, searcher in ipairs(package.loaders) do
+            local loader = table.pack(searcher(name))
+            if loader[1] then
+                package.loaded[name] = sentinel
+                local result = loader[1](name, table.unpack(loader, 2, loader.n))
+                if result == nil then result = true end
+
+                package.loaded[name] = result
+                return result
+            else
+                sError = sError .. "\n  " .. loader[2]
+            end
+        end
+        error(sError, 2)
+    end
+end
+
+--- Build an implementation of Lua's @{package} library, and a @{require}
+-- function to load modules within it.
+--
+-- @tparam table env The environment to load packages into.
+-- @tparam string dir The directory that relative packages are loaded from.
+-- @treturn function The new @{require} function.
+-- @treturn table The new @{package} library.
+local function make_package(env, dir)
+    expect(1, env, "table")
+    expect(2, dir, "string")
+
+    local package = {}
+    package.loaded = {
+        _G = _G,
+        bit = bit,
+        bit32 = bit32,
+        coroutine = coroutine,
+        ffi = ffi,
+        jit = jit,
+        math = math,
+        package = package,
+        string = string,
+        table = table,
+    }
+    package.path = "?;?.lua;?/init.lua;/rom/modules/main/?;/rom/modules/main/?.lua;/rom/modules/main/?/init.lua"..(settings and settings.get("shell.append_path") or "")
+    if turtle then
+        package.path = package.path .. ";/rom/modules/turtle/?;/rom/modules/turtle/?.lua;/rom/modules/turtle/?/init.lua"
+    elseif commands then
+        package.path = package.path .. ";/rom/modules/command/?;/rom/modules/command/?.lua;/rom/modules/command/?/init.lua"
+    end
+    package.config = "/\n;\n?\n!\n-"
+    package.preload = {}
+    package.loaders = { preload(package), from_file(package, env) }
+    package.searchpath = make_searchpath(dir)
+
+    return make_require(package), package
+end
+
+return { make = make_package }

--- a/switchcraft/data/computercraft/lua/rom/startup.lua
+++ b/switchcraft/data/computercraft/lua/rom/startup.lua
@@ -1,0 +1,222 @@
+local completion = require "cc.shell.completion"
+
+-- Setup paths
+local sPath = ".:/rom/programs"
+if term.isColor() then
+    sPath = sPath .. ":/rom/programs/advanced"
+end
+if turtle then
+    sPath = sPath .. ":/rom/programs/turtle"
+else
+    sPath = sPath .. ":/rom/programs/rednet:/rom/programs/fun"
+    if term.isColor() then
+        sPath = sPath .. ":/rom/programs/fun/advanced"
+    end
+end
+if pocket then
+    sPath = sPath .. ":/rom/programs/pocket"
+end
+if commands then
+    sPath = sPath .. ":/rom/programs/command"
+end
+if http then
+    sPath = sPath .. ":/rom/programs/http"
+end
+sPath = sPath .. ":/rom/community/programs"
+shell.setPath(sPath)
+help.setPath("/rom/help")
+
+-- Setup aliases
+shell.setAlias("ls", "list")
+shell.setAlias("dir", "list")
+shell.setAlias("cp", "copy")
+shell.setAlias("mv", "move")
+shell.setAlias("rm", "delete")
+shell.setAlias("clr", "clear")
+shell.setAlias("rs", "redstone")
+shell.setAlias("sh", "shell")
+if term.isColor() then
+    shell.setAlias("background", "bg")
+    shell.setAlias("foreground", "fg")
+end
+
+-- Setup completion functions
+
+local function completePastebinPut(shell, text, previous)
+    if previous[2] == "put" then
+        return fs.complete(text, shell.dir(), true, false)
+    end
+end
+shell.setCompletionFunction("rom/programs/alias.lua", completion.build(nil, completion.program))
+shell.setCompletionFunction("rom/programs/cd.lua", completion.build(completion.dir))
+shell.setCompletionFunction("rom/programs/clear.lua", completion.build({ completion.choice, { "screen", "palette", "all" } }))
+shell.setCompletionFunction("rom/programs/copy.lua", completion.build(
+    { completion.dirOrFile, true },
+    completion.dirOrFile
+))
+shell.setCompletionFunction("rom/programs/delete.lua", completion.build({ completion.dirOrFile, many = true }))
+shell.setCompletionFunction("rom/programs/drive.lua", completion.build(completion.dir))
+shell.setCompletionFunction("rom/programs/edit.lua", completion.build(completion.file))
+shell.setCompletionFunction("rom/programs/eject.lua", completion.build(completion.peripheral))
+shell.setCompletionFunction("rom/programs/gps.lua", completion.build({ completion.choice, { "host", "host ", "locate" } }))
+shell.setCompletionFunction("rom/programs/help.lua", completion.build(completion.help))
+shell.setCompletionFunction("rom/programs/id.lua", completion.build(completion.peripheral))
+shell.setCompletionFunction("rom/programs/label.lua", completion.build(
+    { completion.choice, { "get", "get ", "set ", "clear", "clear " } },
+    completion.peripheral
+))
+shell.setCompletionFunction("rom/programs/list.lua", completion.build(completion.dir))
+shell.setCompletionFunction("rom/programs/mkdir.lua", completion.build({ completion.dir, many = true }))
+
+local complete_monitor_extra = { "scale" }
+shell.setCompletionFunction("rom/programs/monitor.lua", completion.build(
+    function(shell, text, previous)
+        local choices = completion.peripheral(shell, text, previous, true)
+        for _, option in pairs(completion.choice(shell, text, previous, complete_monitor_extra, true)) do
+            choices[#choices + 1] = option
+        end
+        return choices
+    end,
+    function(shell, text, previous)
+        if previous[2] == "scale" then
+            return completion.peripheral(shell, text, previous, true)
+        else
+            return completion.programWithArgs(shell, text, previous, 3)
+        end
+    end,
+    {
+        function(shell, text, previous)
+            if previous[2] ~= "scale" then
+                return completion.programWithArgs(shell, text, previous, 3)
+            end
+        end,
+        many = true,
+    }
+))
+
+shell.setCompletionFunction("rom/programs/move.lua", completion.build(
+    { completion.dirOrFile, true },
+    completion.dirOrFile
+))
+shell.setCompletionFunction("rom/programs/redstone.lua", completion.build(
+    { completion.choice, { "probe", "set ", "pulse " } },
+    completion.side
+))
+shell.setCompletionFunction("rom/programs/rename.lua", completion.build(
+    { completion.dirOrFile, true },
+    completion.dirOrFile
+))
+shell.setCompletionFunction("rom/programs/shell.lua", completion.build({ completion.programWithArgs, 2, many = true }))
+shell.setCompletionFunction("rom/programs/type.lua", completion.build(completion.dirOrFile))
+shell.setCompletionFunction("rom/programs/set.lua", completion.build({ completion.setting, true }))
+shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build({ completion.programWithArgs, 2, many = true }))
+shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build({ completion.programWithArgs, 2, many = true }))
+shell.setCompletionFunction("rom/programs/fun/dj.lua", completion.build(
+    { completion.choice, { "play", "play ", "stop " } },
+    completion.peripheral
+))
+shell.setCompletionFunction("rom/programs/fun/speaker.lua", completion.build(
+    { completion.choice, { "play ", "stop " } },
+    function(shell, text, previous)
+        if previous[2] == "play" then return completion.file(shell, text, previous, true)
+        elseif previous[2] == "stop" then return completion.peripheral(shell, text, previous, false)
+        end
+    end,
+    function(shell, text, previous)
+        if previous[2] == "play" then return completion.peripheral(shell, text, previous, false)
+        end
+    end
+))
+shell.setCompletionFunction("rom/programs/fun/advanced/paint.lua", completion.build(completion.file))
+shell.setCompletionFunction("rom/programs/http/pastebin.lua", completion.build(
+    { completion.choice, { "put ", "get ", "run " } },
+    completePastebinPut
+))
+shell.setCompletionFunction("rom/programs/http/gist.lua", completion.build(
+    { completion.choice, { "put ", "get ", "run ", "edit ", "info ", "delete " } },
+    completePastebinPut
+))
+shell.setCompletionFunction("rom/programs/rednet/chat.lua", completion.build({ completion.choice, { "host ", "join " } }))
+shell.setCompletionFunction("rom/programs/command/exec.lua", completion.build(completion.command))
+shell.setCompletionFunction("rom/programs/http/wget.lua", completion.build({ completion.choice, { "run " } }))
+
+if turtle then
+    shell.setCompletionFunction("rom/programs/turtle/go.lua", completion.build(
+        { completion.choice, { "left", "right", "forward", "back", "down", "up" }, true, many = true }
+    ))
+    shell.setCompletionFunction("rom/programs/turtle/turn.lua", completion.build(
+        { completion.choice, { "left", "right" }, true, many = true }
+    ))
+    shell.setCompletionFunction("rom/programs/turtle/equip.lua", completion.build(
+        nil,
+        { completion.choice, { "left", "right" } }
+    ))
+    shell.setCompletionFunction("rom/programs/turtle/unequip.lua", completion.build(
+        { completion.choice, { "left", "right" } }
+    ))
+end
+
+-- Run autorun files
+if fs.exists("/rom/autorun") and fs.isDir("/rom/autorun") then
+    local tFiles = fs.list("/rom/autorun")
+    for _, sFile in ipairs(tFiles) do
+        if string.sub(sFile, 1, 1) ~= "." then
+            local sPath = "/rom/autorun/" .. sFile
+            if not fs.isDir(sPath) then
+                shell.run(sPath)
+            end
+        end
+    end
+end
+
+local function findStartups(sBaseDir)
+    local tStartups = nil
+    local sBasePath = "/" .. fs.combine(sBaseDir, "startup")
+    local sStartupNode = shell.resolveProgram(sBasePath)
+    if sStartupNode then
+        tStartups = { sStartupNode }
+    end
+    -- It's possible that there is a startup directory and a startup.lua file, so this has to be
+    -- executed even if a file has already been found.
+    if fs.isDir(sBasePath) then
+        if tStartups == nil then
+            tStartups = {}
+        end
+        for _, v in pairs(fs.list(sBasePath)) do
+            local sPath = "/" .. fs.combine(sBasePath, v)
+            if not fs.isDir(sPath) then
+                tStartups[#tStartups + 1] = sPath
+            end
+        end
+    end
+    return tStartups
+end
+
+-- Show MOTD
+if settings.get("motd.enable") then
+    shell.run("motd")
+end
+
+-- Run the user created startup, either from disk drives or the root
+local tUserStartups = nil
+if settings.get("shell.allow_startup") then
+    tUserStartups = findStartups("/")
+end
+if settings.get("shell.allow_disk_startup") then
+    for _, sName in pairs(peripheral.getNames()) do
+        if disk.isPresent(sName) and disk.hasData(sName) then
+            local startups = findStartups(disk.getMountPath(sName))
+            if startups then
+                tUserStartups = startups
+                break
+            end
+        end
+    end
+end
+if tUserStartups then
+    for _, v in pairs(tUserStartups) do
+        shell.run(v)
+    end
+end
+
+_G.package.path = _G.package.path..settings.get("shell.append_path")


### PR DESCRIPTION
This is useful for OSes and stuff like unicornpkg cause then you could set shell.append_path to ``;/lib/?.lua;/lib/?/init.lua`` and then do require("cimg2") instead of require("lib.cimg2").